### PR TITLE
Shift RDoc to be a development dependency.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,10 @@ source "http://rubygems.org"
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.
 gem 'httparty', '~> 0.13.1'
-gem "rdoc", "~> 3.12"
 
 group :development do
   gem "jeweler", "~> 2.0.1"
+  gem "rdoc",    "~> 3.12"
 end
 
 group :test do

--- a/quaderno.gemspec
+++ b/quaderno.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Recrea"]
-  s.date = "2014-12-19"
+  s.date = "2015-04-01"
   s.description = " A ruby wrapper for Quaderno API "
   s.email = "carlos@recrea.es"
   s.extra_rdoc_files = [
@@ -103,17 +103,17 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<httparty>, ["~> 0.13.1"])
-      s.add_runtime_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_development_dependency(%q<jeweler>, ["~> 2.0.1"])
+      s.add_development_dependency(%q<rdoc>, ["~> 3.12"])
     else
       s.add_dependency(%q<httparty>, ["~> 0.13.1"])
-      s.add_dependency(%q<rdoc>, ["~> 3.12"])
       s.add_dependency(%q<jeweler>, ["~> 2.0.1"])
+      s.add_dependency(%q<rdoc>, ["~> 3.12"])
     end
   else
     s.add_dependency(%q<httparty>, ["~> 0.13.1"])
-    s.add_dependency(%q<rdoc>, ["~> 3.12"])
     s.add_dependency(%q<jeweler>, ["~> 2.0.1"])
+    s.add_dependency(%q<rdoc>, ["~> 3.12"])
   end
 end
 


### PR DESCRIPTION
RDoc is only used in the Rakefile, which means it's not required to install/use the gem, just to maintain documentation - hence, removing it from being a runtime dependency.

Only noticed this because another gem in my app also relies on RDoc, and the versions conflicted. It's very likely that gem shouldn't have RDoc as a runtime dependency either.