### PR TITLE
Fix URL in Quaderno::Tax.calculate

### DIFF
--- a/lib/quaderno-ruby/tax.rb
+++ b/lib/quaderno-ruby/tax.rb
@@ -8,7 +8,7 @@ module Quaderno
     end
     
     def self.calculate(params)
-      party_response = get("#{self.base_url}/api/v1/taxes/calculate.json", query: params, basic_auth: { username: api_model.auth_token } )
+      party_response = get("#{self.url}taxes/calculate.json", query: params, basic_auth: { username: api_model.auth_token } )
       check_exception_for(party_response, { rate_limit: true, subdomain_or_token: true, id: true })
       new party_response.parsed_response
     end


### PR DESCRIPTION
`Quaderno::Tax.calculate` was still using the `base_url` which was removed in version 1.7.1.