### PR TITLE
Add Exceptions Hierarchy

### DIFF
--- a/lib/quaderno-ruby/exceptions/exceptions.rb
+++ b/lib/quaderno-ruby/exceptions/exceptions.rb
@@ -1,24 +1,27 @@
 module Quaderno
   module Exceptions
-    class InvalidSubdomainOrToken < Exception
+    class BaseException < Exception
     end
 
-    class InvalidID < Exception
+    class InvalidSubdomainOrToken < BaseException
     end
 
-    class RateLimitExceeded < Exception
+    class InvalidID < BaseException
     end
 
-    class HasAssociatedDocuments < Exception
+    class RateLimitExceeded < BaseException
     end
 
-    class RequiredFieldsEmptyOrInvalid < Exception
+    class HasAssociatedDocuments < BaseException
     end
 
-    class ThrottleLimitExceeded < Exception
+    class RequiredFieldsEmptyOrInvalid < BaseException
     end
 
-    class UnsupportedApiVersion < Exception
+    class ThrottleLimitExceeded < BaseException
+    end
+
+    class UnsupportedApiVersion < BaseException
     end
 
     def self.included(receiver)
@@ -30,7 +33,7 @@ module Quaderno
         raise(Quaderno::Exceptions::UnsupportedApiVersion, 'Unsupported API version') if !!(party_response.body =~ /Unsupported API version/)
 
         if params[:throttle_limit].nil? == false
-         raise(Quaderno::Exceptions::ThrottleLimitExceeded, 'Throttle limit exceeded, please try again later') if party_response.response.class == Net::HTTPServiceUnavailable 
+         raise(Quaderno::Exceptions::ThrottleLimitExceeded, 'Throttle limit exceeded, please try again later') if party_response.response.class == Net::HTTPServiceUnavailable
         end
         if params[:rate_limit].nil? == false
           raise(Quaderno::Exceptions::RateLimitExceeded, 'Rate limit exceeded') if party_response.response.class == Net::HTTPForbidden
@@ -45,7 +48,7 @@ module Quaderno
           raise(Quaderno::Exceptions::RequiredFieldsEmptyOrInvalid, party_response.body) if party_response.response.class == Net::HTTPUnprocessableEntity
         end
         if params[:has_documents].nil? == false
-          raise(Quaderno::Exceptions::HasAssociatedDocuments, party_response.body) if party_response.response.class == Net::HTTPClientError 
+          raise(Quaderno::Exceptions::HasAssociatedDocuments, party_response.body) if party_response.response.class == Net::HTTPClientError
         end
       end
     end

--- a/lib/quaderno-ruby/exceptions/exceptions.rb
+++ b/lib/quaderno-ruby/exceptions/exceptions.rb
@@ -1,6 +1,6 @@
 module Quaderno
   module Exceptions
-    class BaseException < Exception
+    class BaseException < StandardError
     end
 
     class InvalidSubdomainOrToken < BaseException

--- a/quaderno.gemspec
+++ b/quaderno.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["Recrea"]
-  s.date = "2016-06-17"
+  s.date = "2016-06-21"
   s.description = " A ruby wrapper for Quaderno API "
   s.email = "carlos@recrea.es"
   s.extra_rdoc_files = [


### PR DESCRIPTION
- Add `BaseException` class to be ancestor for all specific Quaderno exceptions
- Inherit `StandardError` instead of `Exception` 