### PR TITLE
Return rate limit info on each request

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ This will return a hash with the information about your api url, which includes 
  You can ping the service in order to check if it is up with:
 
 ```ruby
-  Quaderno::Base.ping #=> { status: true }
+  Quaderno::Base.ping #=> { status: true, rate_limit_info: { reset: 4, remaining: 0} }
 ```
 
-This will return true if the service is up or false if it is not.
+This will return `status: true` if the service is up or `status: false` if it is not.
 
 ## Check the rate limit
 
 ```ruby
-  Quaderno::Base.ping #=>  { status: false, rate_limit_info: {:reset=>4, :remaining=>0} }
+  Quaderno::Base.ping #=>  { status: false, rate_limit_info: { reset: 4, remaining: 0} }
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Quaderno-ruby is a ruby wrapper for [Quaderno API] (https://github.com/quaderno/quaderno-api).
 
-Current version is 1.16.0 See the changelog [here](https://github.com/quaderno/quaderno-ruby/blob/master/changelog.md)
+Current version is 1.17.0 See the changelog [here](https://github.com/quaderno/quaderno-ruby/blob/master/changelog.md)
 
 ## Installation & Configuration
 
@@ -41,7 +41,7 @@ This will return a hash with the information about your api url, which includes 
  You can ping the service in order to check if it is up with:
 
 ```ruby
-  Quaderno::Base.ping #=> Boolean
+  Quaderno::Base.ping #=> { status: true }
 ```
 
 This will return true if the service is up or false if it is not.
@@ -49,10 +49,24 @@ This will return true if the service is up or false if it is not.
 ## Check the rate limit
 
 ```ruby
-  Quaderno::Base.rate_limit_info #=>  {:reset=>4, :remaining=>0}
+  Quaderno::Base.ping #=>  { status: false, rate_limit_info: {:reset=>4, :remaining=>0} }
+
 ```
 
 This will return a hash with information about the seconds until the rate limit reset and your remaining requests per minute ([check the API documentation for more information](https://github.com/quaderno/quaderno-api#rate-limiting)).
+
+Alternatively, you can check the rate limit for each request by checking the `rate_limit_info` method on the response:
+
+```ruby
+
+  invoices = Quaderno::Invoice.all
+  invoices.rate_limit_info #=> {:reset=> 5, :remaning=>6}
+
+  invoice = Quaderno::Invoice.find INVOICE_ID
+  invoice.rate_limit_info #=> {:reset=>4, :remaining=>5}
+
+  # etc.
+```
 
 ## Reading the values
 
@@ -111,10 +125,10 @@ will update the specified contact with the data of the hash passed as second par
 
 ### Deleting a contact
 ```ruby
-  Quaderno::Contact.delete(id) #=> Boolean
+  Quaderno::Contact.delete(id) #=> Quaderno::Contact
 ```
 
-will delete the contact with the id passed as parameter.
+will delete the contact with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Contact` with the `deleted` attribute set to `true` will be returned.
 
 ## Managing items
 
@@ -148,10 +162,10 @@ will update the specified item with the data of the hash passed as second parame
 
 ### Deleting an item
 ```ruby
-  Quaderno::Item.delete(id) #=> Boolean
+  Quaderno::Item.delete(id) #=> Quaderno::Item
 ```
 
-will delete the item with the id passed as parameter.
+will delete the item with the id passed as parameter.  If the deletion was successful, an instance of `Quaderno::Item` with the `deleted` attribute set to `true` will be returned.
 
 
 ## Managing invoices
@@ -196,10 +210,10 @@ will update the specified invoice with the data of the hash passed as second par
 ### Deleting an invoice
 
 ```ruby
-  Quaderno::Invoice.delete(id) #=> Boolean
+  Quaderno::Invoice.delete(id) #=> Quaderno::Invoice
 ```
 
-will delete the invoice with the id passed as parameter.
+will delete the invoice with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Item` with the `deleted` attribute set to `true` will be returned.
 
 
 ###Adding or removing a payment
@@ -219,7 +233,7 @@ In order to  remove a payment you will need the Invoice instance you want to upd
   invoice.remove_payment(payment_id) #=> Boolean
 ```
 
-###Delivering the invoice
+### Delivering the invoice
 
   In order to deliver the invoice to the default recipient you will need the invoice you want to send.
 
@@ -263,12 +277,12 @@ will update the specified receipt with the data of the hash passed as second par
 ### Deleting an receipt
 
 ```ruby
-  Quaderno::Receipt.delete(id) #=> Boolean
+  Quaderno::Receipt.delete(id) #=> Quaderno::Receipt
 ```
 
-will delete the receipt with the id passed as parameter.
+will delete the receipt with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Receipt` with the `deleted` attribute set to `true` will be returned.
 
-###Delivering the receipt
+### Delivering the receipt
 
   In order to deliver the receipt to the default recipient you will need the receipt you want to send.
 
@@ -319,13 +333,13 @@ will update the specified credit with the data of the hash passed as second para
 ### Deleting a credit
 
 ```ruby
-  Quaderno::Credit.delete(id) #=> Boolean
+  Quaderno::Credit.delete(id) #=> Quaderno::Credit
 ```
 
-will delete the credit with the id passed as parameter.
+will delete the credit with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Credit` with the `deleted` attribute set to `true` will be returned.
 
 
-###Adding or removing a payment
+### Adding or removing a payment
  In order to  add a payment you will need the Credit instance you want to update.
 
 ```ruby
@@ -339,10 +353,12 @@ In order to  remove a payment you will need the Credit instance you want to upda
 
 ```ruby
   credit = Quaderno::Credit.find(credit_id)
-  credit.remove_payment(payment_id) #=> Boolean
+  credit.remove_payment(payment_id) #=> Quaderno::Payment
 ```
 
-###Delivering the credit
+If the deletion was successful, an instance of `Quaderno::Payment` with the `deleted` attribute set to `true` will be returned.
+
+### Delivering the credit
 
   In order to deliver the credit to the default recipient you will need the credit you want to send.
 
@@ -388,10 +404,10 @@ will update the specified estimate with the data of the hash passed as second pa
 ### Deleting an estimate
 
 ```ruby
-  Quaderno::Estimate.delete(id) #=> Boolean
+  Quaderno::Estimate.delete(id) #=> Quaderno::Estimate
 ```
 
-will delete the estimate with the id passed as parameter.
+will delete the estimate with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Contact` with the `deleted` attribute set to `true` will be returned.
 
 
 ###Adding or removing a payment
@@ -411,7 +427,7 @@ In order to  remove a payment you will need the estimate you want to update.
   estimate.remove_payment(payment_id) #=> Boolean
 ```
 
-###Delivering the estimate
+### Delivering the estimate
   In order to deliver the estimate to the default recipient you will need the estimate you want to send.
 
 ```ruby
@@ -453,10 +469,10 @@ will update the specified expense with the data of the hash passed as second par
 
 ### Deleting an expense
 ```ruby
-  Quaderno::Expense.delete(id) #=> Boolean
+  Quaderno::Expense.delete(id) #=> Quaderno::Expense
 ```
 
-will delete the expense with the id passed as parameter.
+will delete the expense with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Expense` with the `deleted` attribute set to `true` will be returned.
 
 
 ## Managing recurrings
@@ -494,10 +510,10 @@ will update the specified recurring with the data of the hash passed as second p
 ### Deleting a recurring
 
 ```ruby
-  Quaderno::Recurring.delete(id) #=> Boolean
+  Quaderno::Recurring.delete(id) #=> Quaderno::Recurring
 ```
 
-will delete the recurring with the id passed as parameter.
+will delete the recurring with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Recurring` with the `deleted` attribute set to `true` will be returned.
 
 
 ## Managing webhooks
@@ -532,9 +548,9 @@ will update the specified webhook with the data of the hash passed as second par
 
 ### Deleting a webhook
 ```ruby
-  Quaderno::Webhook.delete(id) #=> Boolean
+  Quaderno::Webhook.delete(id) #=> Quaderno::Webhook
 ```
-will delete the webhook with the id passed as parameter.
+will delete the webhook with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::Webhook` with the `deleted` attribute set to `true` will be returned.
 
 
 ## Taxes
@@ -597,9 +613,9 @@ will update the specified checkout session with the data of the hash passed as s
 
 ### Deleting a checkout session
 ```ruby
-  Quaderno::CheckoutSession.delete(id) #=> Boolean
+  Quaderno::CheckoutSession.delete(id) #=> Quaderno::CheckoutSession
 ```
-will delete the checkout session with the id passed as parameter.
+will delete the checkout session with the id passed as parameter. If the deletion was successful, an instance of `Quaderno::CheckoutSession` with the `deleted` attribute set to `true` will be returned.
 
 
 ## Exceptions

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ Alternatively, you can check the rate limit for each request by checking the `ra
   invoice = Quaderno::Invoice.find INVOICE_ID
   invoice.rate_limit_info #=> {:reset=>4, :remaining=>5}
 
+  begin
+    deleted_invoice = Quaderno::Invoice.delete(ANOTHER_INVOICE_ID)
+  rescue Quaderno::Exceptions::InvalidSubdomainOrToken => e
+    # If the exception is triggered you can check the rate limit on the raised exception
+    e.rate_limit_info #=> {:reset=>3, :remaining=>4}
+  end
+
+  deleted_invoice.rate_limit_info #=> {:reset=>3, :remaining=>4}
+
   # etc.
 ```
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,13 @@
 # Changelog
 
 ## 1.17.0
-* Added `rate_limit_info` to each response
-* **Breaking change:** `.delete` methods no longer return a `Boolean` but an instance of the removed object with a `deleted` attribute set to `true`
-* **Breaking change:** `Quaderno::Base.ping` no longer returns a boolean but a `Hash` with a `status` attribute and the `rate_limit_info` if available.
+* Added `rate_limit_info` method to each API response
+* **Breaking change:** `.delete` methods no longer returns a boolean but an instance of the removed object with a `deleted` attribute set to `true`
+* **Breaking change:** `Quaderno::Base.ping` no longer returns a boolean but a `Quaderno::Base` instance with a `status` attribute.
+* **Breaking change:** `Quaderno::Base.authorization` no longer returns a `Hash` but a `Quaderno::Base` instance with an `identity` attribute.
+* **Breaking change:** `Quaderno::Base.me` no longer returns a `Hash` but a `Quaderno::Base` instance with all the attributes contained in the previous format.
+* **Breaking change:** `Quaderno::Tax.validate_vat_number` no longer returns a boolean but a `Quaderno::Tax` instance with a `valid` attribute.
+* **Breaking change:** `.deliver` no longer returns a `Hash` but a `Quaderno::Base` instance with a `success` attribute.
 * **Breaking change:** Removed `Quaderno::Base.rate_limit_info`. Now it's an alias of `Quaderno::Base.ping`.
 
 ## 1.16.0

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## 1.17.0
 * Added `rate_limit_info` to each response
-* **Breaking change:** `#delete` no longer returns a `Boolean` but an instance of the removed object with a `deleted` attribute set to `true`
+* **Breaking change:** `.delete` methods no longer return a `Boolean` but an instance of the removed object with a `deleted` attribute set to `true`
 * **Breaking change:** `Quaderno::Base.ping` no longer returns a boolean but a `Hash` with a `status` attribute and the `rate_limit_info` if available.
 * **Breaking change:** Removed `Quaderno::Base.rate_limit_info`. Now it's an alias of `Quaderno::Base.ping`.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,160 +1,167 @@
-#Changelog
-##1.16.0
+# Changelog
+
+## 1.17.0
+* Added `rate_limit_info` to each response
+* **Breaking change:** `#delete` no longer returns a `Boolean` but an instance of the removed object with a `deleted` attribute set to `true`
+* **Breaking change:** `Quaderno::Base.ping` no longer returns a boolean but a `Hash` with a `status` attribute and the `rate_limit_info` if available.
+* **Breaking change:** Removed `Quaderno::Base.rate_limit_info`. Now it's an alias of `Quaderno::Base.ping`.
+
+## 1.16.0
 * Added `Quaderno::CheckoutSession`
 
-##1.15.2
+## 1.15.2
 * Relax `httparty` version requirement.
 
-##1.15.1
+## 1.15.1
 * Fix `Quaderno` load order.
 
-##1.15.0
+## 1.15.0
 * Removed `jeweler` and updated the gem structure.
 
-##1.14.0
+## 1.14.0
 * Added `domestic_taxes`, `sales_taxes`, `vat_moss`, `ec_sales` and `international_taxes` to `Quaderno::Report`
 
-##1.13.2
+## 1.13.2
 * Added index method to `Quaderno::Tax` as `Quaderno::Tax.all()`.
 
-##1.13.1
+## 1.13.1
 * Added `taxes` report to `Quaderno::Report`.
 
-##1.13.0
+## 1.13.0
 * Added `Quaderno::Report`.
 
-##1.12.5
+## 1.12.5
 * Added `create` method to `Quaderno::Income`.
 * Fix `Quaderno::Base.ping` and `Quaderno::Base.me` methods.
 
-##1.12.4
+## 1.12.4
 * Use version headers on taxes requests.
 
-##1.12.3
+## 1.12.3
 * Return integers insteado of strings on pagination readers.
 
-##1.12.2
+## 1.12.2
 * Added `me` method.
 
-##1.12.0
+## 1.12.0
 * Added thread-safe credentials configuration.
 * `all` methods returns a `Quaderno::Object` with pagination info instead of an `Array`
 
-##1.11.2
+## 1.11.2
 * Specify `Content-Type` header so `HTTParty` don't merge the elements within the body content.
 
-##1.11.1
+## 1.11.1
 * Added `retrieve` method for `Quaderno::Contact`, `Quaderno::Invoice`, `Quaderno::Credit`
 * Deprecate `retrieve_customer` as an alias of `retrieve`
 
-##1.11.0
+## 1.11.0
 * Added `Quaderno::Tax.validate_vat_number` method
 
-##1.10.0
+## 1.10.0
  * Added location evidences support
 
-##1.9.2
+## 1.9.2
  * Added `Quaderno::Contact.retrieve` method
  * Code cleanup
  * Update tests
 
-##1.9.1
+## 1.9.1
  * `Quaderno::Base.authorization` raises `Quaderno::Exceptions::InvalidSubdomainOrToken` instead returning false on wrong credentials
  * Inherit from `StandardError` instead of `Exception` for `Quaderno::Exceptions` by **@mvelikov**
 
-##1.9.0
+## 1.9.0
  * Add support for new versioning system
 
-##1.8.0
+## 1.8.0
  * Add Quaderno::Receipt support
  * Fix errors in README
 
-##1.7.3
+## 1.7.3
  * Raise exception on failed updates
 
-##1.7.2
- * Fix URL in `Quaderno::Tax.calculate` by [**@jcxplorer**] (https://github.com/jcxplorer)
+## 1.7.2
+ * Fix URL in `Quaderno::Tax.calculate` by [**@jcxplorer**](https://github.com/jcxplorer)
 
-##1.7.1
+## 1.7.1
  * Breaking change: change configuration options
 
-##1.7.0
+## 1.7.0
  * Added recurring documents
  * Raise existent exception
 
-##1.6.1
+## 1.6.1
  * Fixed typo from old version released as 1.6.0
 
-##1.6.0 (yanked)
+## 1.6.0 (yanked)
  * Crud module refactor
  * Added support for credit notes
 
-##1.5.5
+## 1.5.5
  * Move rdoc as a development dependency
 
-##1.5.4
+## 1.5.4
 * Remove transaction class.
 
-##1.5.3
+## 1.5.3
 * Update `rate_limit_info` to fit the new rate limit
 * Remove transaction information from README (future resource name change)
 * Added new throttle limit exception (will be activated in future releases)
 
-##1.5.1 and 1.5.2
+## 1.5.1 and 1.5.2
 * Remove debugger
 * `Quaderno::Exceptions::RequiredFieldsEmpty` replaced with `Quaderno::Exceptions::RequiredFieldsEmptyOrInvalid`
 
-##1.5.0
+## 1.5.0
 * Added transactions
 * Raise `Quaderno::Exceptions::RequiredFieldsEmpty` for 422 responses
 
-##1.4.2
+## 1.4.2
 * Find method hotfix
 
-##1.4.1
+## 1.4.1
 * Fix wrong method name
 * Use correct organization in url
 * Add short description of the gem
 
-##1.4.0
+## 1.4.0
 * Added taxes calculations support
 * Added webhooks documentation
 
-##1.3.2
+## 1.3.2
 
 * Use new urls format
 
-##1.3.1
+## 1.3.1
 
 * Added sandbox environment
 * Added `to_hash` instance method
 
-##1.3.0
+## 1.3.0
 
 * Removed debug mode
 
-##1.2.2
+## 1.2.2
 
 * Added ruby 2.0.0 compatibility
 
-##1.2.1
+## 1.2.1
 
 * Deleted debugger dependency
 
-##1.2.0
+## 1.2.0
 
 * Added Quaderno webhooks as a resource
 * Added authorization method
 
-##1.1.2
+## 1.1.2
 
 * Fixed minor bugs
 
-##1.1.0
+## 1.1.0
 
 * Added Quaderno items as a resource
 * Added filter in index queries
 
-##1.0.0
+## 1.0.0
 
 * Initial release

--- a/lib/quaderno-ruby.rb
+++ b/lib/quaderno-ruby.rb
@@ -3,6 +3,7 @@ end
 
 require 'ostruct'
 
+require 'quaderno-ruby/helpers/rate_limit'
 require 'quaderno-ruby/exceptions/exceptions'
 require 'quaderno-ruby/helpers/authentication'
 require 'quaderno-ruby/collection'

--- a/lib/quaderno-ruby/behavior/block.rb
+++ b/lib/quaderno-ruby/behavior/block.rb
@@ -19,7 +19,10 @@ module Quaderno::Behavior
         check_exception_for(response, { rate_limit: true, subdomain_or_token: true, id: true })
         doc = response.parsed_response
 
-        new doc
+        object = new doc
+        object.rate_limit_info = response
+
+        object
       end
     end
   end

--- a/lib/quaderno-ruby/behavior/crud.rb
+++ b/lib/quaderno-ruby/behavior/crud.rb
@@ -47,6 +47,7 @@ module Quaderno::Behavior
           array.each { |element| collection << (new element) }
         end
 
+        collection.rate_limit_info = response
         collection.current_page = response.headers['x-pages-currentpage']
         collection.total_pages = response.headers['x-pages-totalpages']
 
@@ -67,7 +68,10 @@ module Quaderno::Behavior
 
         api_model.parse_nested(hash) if is_a_document?
 
-        new hash
+        object = new hash
+        object.rate_limit_info = response
+
+        object
       end
 
       def create(params = {})
@@ -86,7 +90,10 @@ module Quaderno::Behavior
 
         api_model.parse_nested(hash) if is_a_document?
 
-        new hash
+        object = new hash
+        object.rate_limit_info = response
+
+        object
       end
 
       def update(id, params = {})
@@ -105,7 +112,10 @@ module Quaderno::Behavior
 
         api_model.parse_nested(hash) if is_a_document?
 
-        new hash
+        object = new hash
+        object.rate_limit_info = response
+
+        object
       end
 
       def delete(id, options = {})
@@ -117,7 +127,12 @@ module Quaderno::Behavior
         )
         check_exception_for(response, { rate_limit: true, subdomain_or_token: true, id: true, has_documents: true })
 
-        true
+        hash = { deleted: true, id: id }
+
+        object = new hash
+        object.rate_limit_info = response
+
+        object
       end
     end
   end

--- a/lib/quaderno-ruby/behavior/deliver.rb
+++ b/lib/quaderno-ruby/behavior/deliver.rb
@@ -17,7 +17,8 @@ module Quaderno::Behavior
         )
 
         api_model.check_exception_for(party_response, { rate_limit: true, subdomain_or_token: true, id: true, required_fields: true })
-        { limit: party_response.headers["x-ratelimit-limit"].to_i, remaining: party_response.headers["x-ratelimit-remaining"].to_i }
+
+        { reset: party_response.headers['x-ratelimit-reset'].to_i, remaining: party_response.headers["x-ratelimit-remaining"].to_i }
       end
     end
   end

--- a/lib/quaderno-ruby/behavior/deliver.rb
+++ b/lib/quaderno-ruby/behavior/deliver.rb
@@ -18,7 +18,10 @@ module Quaderno::Behavior
 
         api_model.check_exception_for(party_response, { rate_limit: true, subdomain_or_token: true, id: true, required_fields: true })
 
-        { reset: party_response.headers['x-ratelimit-reset'].to_i, remaining: party_response.headers["x-ratelimit-remaining"].to_i }
+        data = Quaderno::Base.new(success: true)
+        data.rate_limit_info = party_response
+
+        data
       end
     end
   end

--- a/lib/quaderno-ruby/behavior/payment.rb
+++ b/lib/quaderno-ruby/behavior/payment.rb
@@ -25,12 +25,13 @@ module Quaderno::Behavior
         instance = Quaderno::Payment.new(response.parsed_response)
         self.payments << instance
 
-        Quaderno::Payment.new instance
+        instance.rate_limit_info = response
+
+        instance
       end
 
       def remove_payment(payment_id, options = nil)
         self.authentication_data = get_authentication(options.merge(api_model: api_model)) if options.is_a?(Hash)
-
 
         response = HTTParty.delete("#{authentication_data[:url]}#{api_model.api_path}/#{id}/payments/#{payment_id}.json",
           basic_auth: authentication_data[:basic_auth],
@@ -41,7 +42,12 @@ module Quaderno::Behavior
 
         self.payments.delete_if { |payment| payment.id == payment_id }
 
-        true
+        hash = { deleted: true, id: payment_id}
+
+        object = Quaderno::Payment.new(hash)
+        object.rate_limit_info = response
+
+        object
       end
     end
   end

--- a/lib/quaderno-ruby/behavior/retrieve.rb
+++ b/lib/quaderno-ruby/behavior/retrieve.rb
@@ -20,7 +20,10 @@ module Quaderno::Behavior
         hash = response.parsed_response
         hash[:authentication_data] = authentication
 
-        new hash
+        object = new hash
+        object.rate_limit_info = response
+
+        object
       end
       alias_method :retrieve_customer, :retrieve
 

--- a/lib/quaderno-ruby/collection.rb
+++ b/lib/quaderno-ruby/collection.rb
@@ -1,4 +1,5 @@
 class Quaderno::Collection < Array
+  include Quaderno::Helpers::RateLimit
 
   def current_page=(page_number)
     @page = page_number

--- a/lib/quaderno-ruby/helpers/rate_limit.rb
+++ b/lib/quaderno-ruby/helpers/rate_limit.rb
@@ -1,0 +1,12 @@
+module Quaderno::Helpers
+  module RateLimit
+
+    def rate_limit_info=(response)
+      @rate_limit_info = { reset: response.headers['x-ratelimit-reset'].to_i, remaining: response.headers["x-ratelimit-remaining"].to_i }
+    end
+
+    def rate_limit_info
+      @rate_limit_info
+    end
+  end
+end

--- a/lib/quaderno-ruby/payment.rb
+++ b/lib/quaderno-ruby/payment.rb
@@ -1,2 +1,3 @@
 class Quaderno::Payment < OpenStruct
+  include Quaderno::Helpers::RateLimit
 end

--- a/lib/quaderno-ruby/tax.rb
+++ b/lib/quaderno-ruby/tax.rb
@@ -20,7 +20,10 @@ class Quaderno::Tax < Quaderno::Base
     )
 
     check_exception_for(response, { rate_limit: true, subdomain_or_token: true, id: true })
-    new response.parsed_response
+    data = new response.parsed_response
+    data.rate_limit_info = response
+
+    data
   end
 
   def self.validate_vat_number(country, vat_number, options = {})
@@ -34,7 +37,10 @@ class Quaderno::Tax < Quaderno::Base
 
     check_exception_for(response, { rate_limit: true, subdomain_or_token: true, id: true })
 
-    response.parsed_response['valid']
+    data = new({ valid: response.parsed_response['valid'] })
+    data.rate_limit_info = response
+
+    data
   end
 
   def self.reports(options = {})
@@ -49,6 +55,7 @@ class Quaderno::Tax < Quaderno::Base
 
     array = response.parsed_response
     collection = Quaderno::Collection.new
+    collection.rate_limit_info = response
     collection.current_page = response.headers['x-pages-currentpage']
     collection.total_pages = response.headers['x-pages-totalpages']
 

--- a/lib/quaderno-ruby/version.rb
+++ b/lib/quaderno-ruby/version.rb
@@ -1,3 +1,3 @@
 class Quaderno
-  VERSION = "1.16.0"
+  VERSION = "1.17.0"
 end

--- a/quaderno.gemspec
+++ b/quaderno.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('webmock', "~> 1.22.6")
   spec.add_development_dependency('vcr', ">= 0")
   spec.add_development_dependency("bundler", "~> 1.11")
-  spec.add_development_dependency("rake", "~> 10.0")
+  spec.add_development_dependency("rake", ">= 12.3.3")
   spec.add_development_dependency("rspec", "~> 3.0")
 end

--- a/spec/unit/test_quaderno_checkout_sessions.rb
+++ b/spec/unit/test_quaderno_checkout_sessions.rb
@@ -137,8 +137,8 @@ describe Quaderno::CheckoutSession do
 
     it 'should know the rate limit' do
       VCR.use_cassette('rate limit') do
-        rate_limit_info = Quaderno::Base.rate_limit_info
-        expect(rate_limit_info[:remaining] < 2000).to be true
+        result = Quaderno::Base.rate_limit_info
+        expect(result.rate_limit_info[:remaining] < 2000).to be true
       end
     end
   end

--- a/spec/unit/test_quaderno_contacts.rb
+++ b/spec/unit/test_quaderno_contacts.rb
@@ -60,8 +60,8 @@ describe Quaderno::Contact do
 
     it 'should know the rate limit' do
       VCR.use_cassette('rate limit') do
-        rate_limit_info = Quaderno::Base.rate_limit_info
-        expect(rate_limit_info[:remaining] < 2000).to be true
+        result = Quaderno::Base.rate_limit_info
+        expect(result.rate_limit_info[:remaining] < 2000).to be true
       end
     end
   end

--- a/spec/unit/test_quaderno_estimates.rb
+++ b/spec/unit/test_quaderno_estimates.rb
@@ -99,7 +99,7 @@ describe Quaderno::Estimate do
     it 'should deliver an estimate' do
       VCR.use_cassette('delivered estimate') do
         estimates = Quaderno::Estimate.all
-        rate_limit_before = Quaderno::Base.rate_limit_info
+        rate_limit_before = Quaderno::Base.ping.rate_limit_info
         begin
           rate_limit_after = estimates.first.deliver
         rescue Quaderno::Exceptions::RequiredFieldsEmptyOrInvalid

--- a/spec/unit/test_quaderno_invoices.rb
+++ b/spec/unit/test_quaderno_invoices.rb
@@ -101,7 +101,7 @@ describe Quaderno::Invoice do
     it 'should deliver an invoice' do
       VCR.use_cassette('delivered invoice') do
         invoices = Quaderno::Invoice.all
-        rate_limit_before = Quaderno::Base.rate_limit_info
+        rate_limit_before = Quaderno::Base.ping.rate_limit_info
         begin
           rate_limit_after = invoices.first.deliver
         rescue Quaderno::Exceptions::RequiredFieldsEmptyOrInvalid

--- a/spec/unit/test_quaderno_items.rb
+++ b/spec/unit/test_quaderno_items.rb
@@ -60,7 +60,7 @@ describe Quaderno::Item do
 
     it 'should know the rate limit' do
       VCR.use_cassette('rate limit') do
-        rate_limit_info = Quaderno::Base.rate_limit_info
+        rate_limit_info = Quaderno::Base.ping.rate_limit_info
         expect(rate_limit_info[:remaining] < 2000).to be true
       end
     end

--- a/spec/unit/test_quaderno_receipts.rb
+++ b/spec/unit/test_quaderno_receipts.rb
@@ -103,7 +103,7 @@ describe Quaderno::Receipt do
     it 'should deliver an receipt' do
       VCR.use_cassette('delivered receipt') do
         receipts = Quaderno::Receipt.all
-        rate_limit_before = Quaderno::Base.rate_limit_info
+        rate_limit_before = Quaderno::Base.ping.rate_limit_info
         begin
           rate_limit_after = receipts.first.deliver
         rescue Quaderno::Exceptions::RequiredFieldsEmptyOrInvalid

--- a/spec/unit/test_quaderno_tax.rb
+++ b/spec/unit/test_quaderno_tax.rb
@@ -20,12 +20,12 @@ describe Quaderno::Tax do
 
     it 'should validate VAT numbe' do
       VCR.use_cassette('validate valid VAT number') do
-        vat_number_valid = Quaderno::Tax.validate_vat_number('IE', 'IE6388047V')
+        vat_number_valid = Quaderno::Tax.validate_vat_number('IE', 'IE6388047V').valid
         expect(vat_number_valid).to be true
       end
 
        VCR.use_cassette('validate invalid VAT number') do
-        vat_number_valid = Quaderno::Tax.validate_vat_number('IE', 'IE6388047X')
+        vat_number_valid = Quaderno::Tax.validate_vat_number('IE', 'IE6388047X').valid
         expect(!vat_number_valid).to be true
       end
     end

--- a/spec/unit/test_quaderno_webhooks.rb
+++ b/spec/unit/test_quaderno_webhooks.rb
@@ -69,7 +69,7 @@ describe Quaderno::Webhook do
 
     it 'should know the rate limit' do
       VCR.use_cassette('rate limit') do
-        rate_limit_info = Quaderno::Base.rate_limit_info
+        rate_limit_info = Quaderno::Base.ping.rate_limit_info
         expect(rate_limit_info[:remaining] < 2000).to be true
       end
     end


### PR DESCRIPTION
Description same as title. Now each request response will have a method or attribute `rate_limit_info`. This method is thread-safe for users who don't use the global configuration.


```ruby

  invoices = Quaderno::Invoice.all
  invoices.rate_limit_info #=> {:reset=> 5, :remaning=>6}

  invoice = Quaderno::Invoice.find INVOICE_ID
  invoice.rate_limit_info #=> {:reset=>4, :remaining=>5}

  begin
    deleted_invoice = Quaderno::Invoice.delete(ANOTHER_INVOICE_ID)
  rescue Quaderno::Exceptions::InvalidSubdomainOrToken => e
    # If the exception is triggered you can check the rate limit on the raised exception
    e.rate_limit_info #=> {:reset=>3, :remaining=>4}
  end

  deleted_invoice.rate_limit_info #=> {:reset=>3, :remaining=>4}

  # etc.
```