### PR TITLE
Fix missing version require

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Quaderno-ruby is a ruby wrapper for [Quaderno API] (https://github.com/quaderno/quaderno-api).
 
-Current version is 1.17.0 See the changelog [here](https://github.com/quaderno/quaderno-ruby/blob/master/changelog.md)
+Current version is 2.0.1 See the changelog [here](https://github.com/quaderno/quaderno-ruby/blob/master/changelog.md)
 
 ## Installation & Configuration
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+* Fix an issue where requests would result in an error due to a missing `require`
+
 ## 2.0.0
 * **Breaking change** Pagination strategy has been updated to be cursor based. Collections no longer offer the `current_page` and `total_pages` methods, and offer `has_more?` and `next_page` instead. The `page` parameter is no longer supported either, in favour of the `created_before` parameter. [See more information in the documentation](https://developers.quaderno.io/api/#pagination).
 * **Breaking change** `Quaderno::Tax.calculate` uses the [new tax calculation endpoint](https://developers.quaderno.io/api/#calculate-a-tax-rate). This endpoint accepts address parameters with the prefix `to_`. For example, `postal_code` is deprecated in favour of `to_postal_code`.

--- a/lib/quaderno-ruby.rb
+++ b/lib/quaderno-ruby.rb
@@ -3,6 +3,7 @@ end
 
 require 'ostruct'
 
+require 'quaderno-ruby/version'
 require 'quaderno-ruby/helpers/rate_limit'
 require 'quaderno-ruby/exceptions/exceptions'
 require 'quaderno-ruby/helpers/authentication'

--- a/lib/quaderno-ruby/version.rb
+++ b/lib/quaderno-ruby/version.rb
@@ -1,3 +1,3 @@
 class Quaderno
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end


### PR DESCRIPTION
Doing any request would result in an error due to `Quaderno::Version` not being specified.

I didn't detect this earlier, since I had initially added the version in the base `quaderno-ruby` file. Once I saw that the version was being declared somewhere else, I changed the code without re-testing.

Speaking of which, this repository could use some CI 🤔 