### PR TITLE
Update tax methods and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,17 +527,17 @@ will delete the webhook with the id passed as parameter. If the deletion was suc
 
 will calculate the taxes applied for a customer based on the data pased as parameters.
 
-### Validate VAT numbers
+### Validate tax ID
 ```ruby
  country = 'IE'
- vat_number = 'IE6388047V'
+ tax_id = 'IE6388047V'
 
- result = Quaderno::Tax.validate_vat_number(country, vat_number) #=> Quaderno::Tax
+ result = Quaderno::Tax.validate_tax_id(country, tax_id) #=> Quaderno::Tax
 
  result.valid #=> Boolean or nil
 ```
 
-will validate the vat number for the passed country.
+will validate the tax ID or business number for the specified country.
 
 ## Evidences
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+* Fix an issue with the parameters sent during the `validate_vat_number` request
+* Renames `validate_vat_number` into `validate_tax_id`
+
 ## 2.0.1
 * Fix an issue where requests would result in an error due to a missing `require`
 

--- a/lib/quaderno-ruby/tax.rb
+++ b/lib/quaderno-ruby/tax.rb
@@ -26,11 +26,11 @@ class Quaderno::Tax < Quaderno::Base
     data
   end
 
-  def self.validate_vat_number(country, vat_number, options = {})
+  def self.validate_tax_id(country, tax_id, options = {})
     authentication = get_authentication(options.merge(api_model: api_model))
 
     response = get("#{authentication[:url]}tax_ids/validate.json",
-      query: { country: country, vat_number: vat_number },
+      query: { country: country, tax_id: tax_id },
       basic_auth: authentication[:basic_auth],
       headers: default_headers.merge(authentication[:headers])
     )
@@ -42,6 +42,8 @@ class Quaderno::Tax < Quaderno::Base
 
     data
   end
+  # TODO: Temporary alias to be removed in future releases
+  self.singleton_class.send(:alias_method, :validate_vat_number, :validate_tax_id)
 
   def self.reports(options = {})
     authentication = get_authentication(options.merge(api_model: api_model))

--- a/lib/quaderno-ruby/version.rb
+++ b/lib/quaderno-ruby/version.rb
@@ -1,3 +1,3 @@
 class Quaderno
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end

--- a/spec/fixtures/quaderno_cassettes/validate_invalid_tax_ID.yml
+++ b/spec/fixtures/quaderno_cassettes/validate_invalid_tax_ID.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://sk_test_bMz9mJJ5bZnWPwWGuV8y:@quaderno.lvh.me:3000/api/tax_ids/validate.json?country=IE&vat_number=IE6388047X
+    uri: http://sk_test_bMz9mJJ5bZnWPwWGuV8y:@quaderno.lvh.me:3000/api/tax_ids/validate.json?country=IE&tax_id=IE6388047X
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/quaderno_cassettes/validate_valid_tax_ID.yml
+++ b/spec/fixtures/quaderno_cassettes/validate_valid_tax_ID.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://sk_test_bMz9mJJ5bZnWPwWGuV8y:@quaderno.lvh.me:3000/api/tax_ids/validate.json?country=IE&vat_number=IE6388047V
+    uri: http://sk_test_bMz9mJJ5bZnWPwWGuV8y:@quaderno.lvh.me:3000/api/tax_ids/validate.json?country=IE&tax_id=IE6388047V
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/quaderno_cassettes/wrong_token.yml
+++ b/spec/fixtures/quaderno_cassettes/wrong_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://quaderno.lvh.me:3000/api/tax_rates/calculate.json?to_country=ES&to_postal_code=08080
+    uri: http://7h15154f4k370k3n:@quaderno.lvh.me:3000/api/tax_rates/calculate.json?to_country=ES&to_postal_code=08080
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/unit/test_quaderno_tax.rb
+++ b/spec/unit/test_quaderno_tax.rb
@@ -14,19 +14,30 @@ describe Quaderno::Tax do
     it 'should raise exception if token is wrong' do
       VCR.use_cassette('wrong token') do
         Quaderno::Base.auth_token = '7h15154f4k370k3n'
-        expect { Quaderno::Tax.calculate(country: 'ES', postal_code: '08080') }.to raise_error(Quaderno::Exceptions::InvalidSubdomainOrToken)
+        expect { Quaderno::Tax.calculate(to_country: 'ES', to_postal_code: '08080') }.to raise_error(Quaderno::Exceptions::InvalidSubdomainOrToken)
       end
     end
 
-    it 'should validate VAT numbe' do
-      VCR.use_cassette('validate valid VAT number') do
+    it 'should validate tax ID' do
+      # TODO: validate_vat_number is a legacy alias. Should be removed in an upcoming release
+      VCR.use_cassette('validate valid tax ID') do
         vat_number_valid = Quaderno::Tax.validate_vat_number('IE', 'IE6388047V').valid
         expect(vat_number_valid).to be true
       end
 
-       VCR.use_cassette('validate invalid VAT number') do
+       VCR.use_cassette('validate invalid tax ID') do
         vat_number_valid = Quaderno::Tax.validate_vat_number('IE', 'IE6388047X').valid
         expect(!vat_number_valid).to be true
+      end
+
+      VCR.use_cassette('validate valid tax ID') do
+        tax_id_valid = Quaderno::Tax.validate_tax_id('IE', 'IE6388047V').valid
+        expect(tax_id_valid).to be true
+      end
+
+       VCR.use_cassette('validate invalid tax ID') do
+        tax_id_valid = Quaderno::Tax.validate_tax_id('IE', 'IE6388047X').valid
+        expect(!tax_id_valid).to be true
       end
     end
   end


### PR DESCRIPTION
Fix the arguments passed to the validation endpoint and some tests. Also renames the validation method from `validate_vat_number` to `validate_tax_id` which suits better to the API resource.