### PR TITLE
Return next page cursor

### DIFF
--- a/lib/quaderno-ruby/collection.rb
+++ b/lib/quaderno-ruby/collection.rb
@@ -21,6 +21,12 @@ class Quaderno::Collection < Array
     @has_more == 'true'
   end
 
+  def next_page_cursor
+    return unless @next_page_url
+
+    @next_page_url.to_s.match(/created_before=(\d+)/)&.[](1)
+  end
+
   def next_page
     return Quaderno::Collection.new unless has_more?
     @collection_type.all_from_url(@next_page_url, @request_options)


### PR DESCRIPTION
Additionally to the `next_page_url`, return the next page cursor as an independent value.