### PR TITLE
Allow custom user agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To configure just add this to your initializers
     config.auth_token = 'my_authenticate_token'
     config.url = 'https://my_subdomain.quadernoapp.com/api/'
     config.api_version = API_VERSION # Optional, defaults to the API version set in your account
+    config.user_agent_header = 'my custom user agent' # Optional, will make support for your account more efficient if you are doing oauth integrations
   end
 ```
 

--- a/lib/quaderno-ruby/base.rb
+++ b/lib/quaderno-ruby/base.rb
@@ -15,6 +15,7 @@ class Quaderno::Base < OpenStruct
   @@rate_limit_info = nil
   @@api_version = nil
   @@url = PRODUCTION_URL
+  @@user_agent_suffix = nil
 
   # Class methods
   def self.api_model(klass)
@@ -140,7 +141,7 @@ class Quaderno::Base < OpenStruct
   end
 
   def self.user_agent_header
-    { "User-Agent" => "Quaderno Ruby Gem #{Quaderno::VERSION}" }
+    @_user_agent_header ||= { "User-Agent" => ["Quaderno Ruby Gem #{Quaderno::VERSION}", @@user_agent_suffix].compact.join(' - ') }
   end
 
   def self.version_header


### PR DESCRIPTION
When making oauth requests, Quaderno has an easier time tracing requests if they have a custom user agent, since the authentication will be done via an auth token.

This PR does not bump the gem version because there is another improvement that I want to add before launching a new gem version.