### PR TITLE
Add new exception for Quaderno ServerErrors

### DIFF
--- a/lib/quaderno-ruby/base.rb
+++ b/lib/quaderno-ruby/base.rb
@@ -56,6 +56,8 @@ class Quaderno::Base < OpenStruct
       data.rate_limit_info = response
 
       data
+    elsif response.response.is_a?(Net::HTTPServerError)
+      raise_exception(Quaderno::Exceptions::ServerError, 'Server error', response)
     else
       raise_exception(Quaderno::Exceptions::InvalidSubdomainOrToken, 'Invalid subdomain or token', response)
     end

--- a/lib/quaderno-ruby/exceptions/exceptions.rb
+++ b/lib/quaderno-ruby/exceptions/exceptions.rb
@@ -24,6 +24,9 @@ module Quaderno::Exceptions
   class UnsupportedApiVersion < BaseException
   end
 
+  class ServerError < BaseException
+  end
+
   def self.included(receiver)
     receiver.send :extend, ClassMethods
   end
@@ -50,6 +53,8 @@ module Quaderno::Exceptions
       if params[:has_documents].nil? == false
         raise_exception(Quaderno::Exceptions::HasAssociatedDocuments, party_response.body, party_response) if party_response.response.class == Net::HTTPClientError
       end
+
+      raise_exception(Quaderno::Exceptions::ServerError, 'Server error', response) if party_response.response.is_a?(Net::HTTPServerError)
     end
 
     def raise_exception(klass, message, response)


### PR DESCRIPTION
This PR adds a new exception to track all errors under the 50X status code family.

This is particularly useful in `Quaderno::Base.authorization`, which was raising `Quaderno::Exceptions::InvalidSubdomainOrToken` exceptions when Quaderno returned 502 errors due to performance issues.

I hope to release version 2.1.0 of the gem after this is released.