### PR TITLE
Fix reference to non-existent variable

### DIFF
--- a/lib/quaderno-ruby/exceptions/exceptions.rb
+++ b/lib/quaderno-ruby/exceptions/exceptions.rb
@@ -54,7 +54,7 @@ module Quaderno::Exceptions
         raise_exception(Quaderno::Exceptions::HasAssociatedDocuments, party_response.body, party_response) if party_response.response.class == Net::HTTPClientError
       end
 
-      raise_exception(Quaderno::Exceptions::ServerError, 'Server error', response) if party_response.response.is_a?(Net::HTTPServerError)
+      raise_exception(Quaderno::Exceptions::ServerError, 'Server error', party_response) if party_response.response.is_a?(Net::HTTPServerError)
     end
 
     def raise_exception(klass, message, response)


### PR DESCRIPTION
Context: While trying to use `Quaderno::Base.ping`, I got this error:
```ruby
irb(main):001:0> Quaderno::Base.ping
NameError: undefined local variable or method `response' for Quaderno::Base:Class
Did you mean?  respond_to?
        from .../vendor/bundle/ruby/2.4.0/gems/quaderno-2.1.1/lib/quaderno-ruby/exceptions/exceptions.rb:57:in `check_exception_for'
```

Further digging into the code, it seems like this was a typo with the original implementation.

- Introduced by #24