### PR TITLE
Update httparty to 0.21.0

### DIFF
--- a/quaderno.gemspec
+++ b/quaderno.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.date = '2018-05-07'
   spec.extra_rdoc_files = %w(LICENSE.txt README.md)
 
-  spec.add_dependency('httparty', '~> 0.13')
+  spec.add_dependency('httparty', '~> 0.21.0')
   spec.add_development_dependency('rdoc', '>= 6.3.1')
   spec.add_development_dependency('activesupport', '~> 4.2.0')
   spec.add_development_dependency('webmock', '~> 1.22.6')


### PR DESCRIPTION
There is a vulnerability with httparty in its current version. 

There should be no breaking changes with this version bump. However the minimum required version of ruby will be changed to >= 2.3.0 https://github.com/jnunemaker/httparty/blob/master/Changelog.md

<img width="1055" alt="image" src="https://user-images.githubusercontent.com/22102275/217333825-0daed73e-4fec-4e9a-843d-109d971f1687.png">
