### PR TITLE
Update activesupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Quaderno-ruby is a ruby wrapper for the [Quaderno API](https://developers.quaderno.io/api).
 
-Current version is 3.0.0 → See the changelog [here](https://github.com/quaderno/quaderno-ruby/blob/master/changelog.md).
+Current version is 3.0.1 → See the changelog [here](https://github.com/quaderno/quaderno-ruby/blob/master/changelog.md).
 
 To learn more about our API and ecosystem, check [developers.quaderno.io](https://developers.quaderno.io).
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.1
+* Security: update development dependency activesupport to 6.1.7.3
+
 ## 3.0.0
 * Added support for accounts API
 * Added support for addresses API

--- a/lib/quaderno-ruby/version.rb
+++ b/lib/quaderno-ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Quaderno
-  VERSION = "3.0.0"
+  VERSION = "3.0.1"
 end

--- a/quaderno.gemspec
+++ b/quaderno.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = %w(LICENSE.txt README.md)
 
   spec.add_dependency('httparty', '~> 0.21')
-  spec.add_development_dependency('activesupport', '~> 4.2.0')
+  spec.add_development_dependency('activesupport', '~> 6.1.7.3')
   spec.add_development_dependency('bundler', '~> 2.2')
   spec.add_development_dependency('rake', '>= 12.3.3')
   spec.add_development_dependency('rdoc', '>= 6.3.1')


### PR DESCRIPTION
Bump development dependency `activesupport` to 6.1.7.3 from 4.2

Fixes:
- CVE-2023-22796 Low severity
- CVE-2023-28120 Moderate severity

